### PR TITLE
Smear configuration changes over time.

### DIFF
--- a/configs/crdb-local/prod.yaml
+++ b/configs/crdb-local/prod.yaml
@@ -6,28 +6,28 @@ frontends:
     idleDuration: 5m
     backendPool:
       tiers:
-        - maxBackendConnections: 64
+        - maxBackendConnections: 256
           targets:
             - hosts: # East
-                - 10.142.0.51
-                - 10.142.0.52
-                - 10.142.0.54
+                - 10.142.0.85
+                - 10.142.0.89
+                - 10.142.0.86
               port: 26257
-        - maxBackendConnections: 32
+        - maxBackendConnections: 128
           forcePromotionAfter: 1m
           targets:
             - hosts: # West
-                - 10.138.0.43
-                - 10.138.0.87
-                - 10.138.0.48
+                - 10.138.0.12
+                - 10.138.0.7
+                - 10.138.0.5
               port: 26257
         - maxBackendConnections: 8
           forcePromotionAfter: 15s
           targets:
             - hosts: # Europe
-                - 10.154.0.8
-                - 10.154.0.13
-                - 10.154.0.70
+                - 10.154.0.73
+                - 10.154.0.75
+                - 10.154.0.72
               port: 26257
 
   - bindAddress: :8080
@@ -36,20 +36,20 @@ frontends:
       tiers:
         - targets:
             - hosts: # East
-                - 10.142.0.51
-                - 10.142.0.52
-                - 10.142.0.54
+                - 10.142.0.85
+                - 10.142.0.89
+                - 10.142.0.86
               port: 26258
         - targets:
             - hosts: # West
-                - 10.138.0.43
-                - 10.138.0.87
-                - 10.138.0.48
+                - 10.138.0.12
+                - 10.138.0.7
+                - 10.138.0.5
               port: 26258
         - targets:
             - hosts: # Europe
-                - 10.154.0.8
-                - 10.154.0.13
-                - 10.154.0.70
+                - 10.154.0.73
+                - 10.154.0.75
+                - 10.154.0.72
               port: 26258
 gracePeriod: 5s

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,12 +75,20 @@ func (f *Frontend) Validate() error {
 
 // BackendPool represents the actual machines to connect to.
 type BackendPool struct {
+	// How often connections within the pool should be evaluated for
+	// over-load conditions, promotion to a higher tier, etc.
+	// Longer values provide better damping of behavior, at the cost
+	// of simply taking more time to effect configuration changes.
+	MaintenanceTime time.Duration `yaml:"maintenanceTime"`
 	// Backends are arranged in tiers with a "fill and spill" behavior.
 	Tiers []Tier `yaml:"tiers"`
 }
 
 // Validate checks the value.
 func (b *BackendPool) Validate() error {
+	if b.MaintenanceTime == 0 {
+		b.MaintenanceTime = 30 * time.Second
+	}
 	if len(b.Tiers) == 0 {
 		return errors.New("Tiers must not be empty")
 	}

--- a/pkg/frontend/smoke_test.go
+++ b/pkg/frontend/smoke_test.go
@@ -71,6 +71,9 @@ func TestSmoke(t *testing.T) {
 			},
 		},
 	}
+	if !a.NoError(cfg.Validate()) {
+		return
+	}
 
 	fe := frontend.Frontend{}
 	if !a.NoError(fe.Ensure(ctx, cfg)) {

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -21,7 +21,8 @@ import (
 	"sync"
 )
 
-// A Pool provides a tiered, round-robin selection mechanism.
+// A Pool provides a weighted, tiered, round-robin selection mechanism
+// for instances of pool.Entry.
 //
 // A Pool must not be copied after first use.
 type Pool struct {
@@ -32,9 +33,11 @@ type Pool struct {
 		canonical map[Entry]*entryMeta
 		// Mark is a monotonic counter that's used to create a
 		// round-robin effect.
-		mark uint64
+		mark mark
 		q    entryPQueue
-		// Broadcasts calls to Add and Rebalance. Synchronized on mu.
+		// Broadcasts calls to Add, Rebalance, and Release.
+		//
+		// Synchronized on mu.
 		pickMightSucceed *sync.Cond
 	}
 }
@@ -54,19 +57,19 @@ func (p *Pool) Add(e Entry) {
 	}
 
 	p.mu.canonical[e] = p.mu.q.add(e)
-
-	if p.mu.pickMightSucceed != nil {
-		p.mu.pickMightSucceed.Broadcast()
-	}
+	p.pickMightSucceedLocked()
 }
 
-// All returns all entries currently in the Pool.
+// All returns all entries currently in the Pool, sorted by preference.
 func (p *Pool) All() []Entry {
 	p.mu.Lock()
 	all := make([]*entryMeta, len(p.mu.q))
 	copy(all, p.mu.q)
 	p.mu.Unlock()
 
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].costLowerThan(all[j])
+	})
 	ret := make([]Entry, len(all))
 	for i := range ret {
 		ret[i] = all[i].Entry
@@ -77,9 +80,21 @@ func (p *Pool) All() []Entry {
 // Len returns the total size of the pool.
 func (p *Pool) Len() int {
 	p.mu.Lock()
-	ret := len(p.mu.q)
-	p.mu.Unlock()
-	return ret
+	defer p.mu.Unlock()
+
+	return len(p.mu.q)
+}
+
+// Load returns the currently outstanding load count on the entry.
+func (p *Pool) Load(e Entry) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	meta := p.mu.canonical[e]
+	if meta == nil {
+		return 0
+	}
+	return meta.load
 }
 
 // MarshalYAML dumps the current status of the Pool into a YAML structure.
@@ -106,24 +121,63 @@ func (p *Pool) MarshalYAML() (interface{}, error) {
 	return payload, nil
 }
 
-// Pick will return the next Entry to use.
-func (p *Pool) Pick() Entry {
+// Peek is a shortcut for PickLoad(0).
+//
+// This effectively returns the best-guess as to the next Entry to
+// be returned from the pool.
+func (p *Pool) Peek() *Token {
+	return p.PickLoad(0)
+}
+
+// Pick is a shortcut for PickLoad(1).
+func (p *Pool) Pick() *Token {
+	return p.PickLoad(1)
+}
+
+// PickLoad will return a Token that provides access to an Entry in the
+// pool that has at least the requested load available.
+//
+// The Token exists to act as a reference-counter on the Entry to
+// ensure that no more than Entry.MaxLoad() Tokens exist for than entry
+// when Pick is called.
+//
+// Token.Release() should be called once the Entry is no longer needed
+// by the caller. A GC finalizer will be set up to avoid leaks, but the
+// timing of the GC cannot be relied upon for correctness.
+func (p *Pool) PickLoad(load int) *Token {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.pickLocked()
+	return p.pickLocked(load)
 }
 
 // Choose the best enabled entry.
-func (p *Pool) pickLocked() Entry {
-	for range p.mu.q {
-		top := p.mu.q[0]
-		p.mu.mark++
-		p.mu.q.update(top, p.mu.mark)
+func (p *Pool) pickLocked(load int) *Token {
+	if len(p.mu.q) == 0 {
+		return nil
+	}
 
-		if !top.disabled {
-			return top.Entry
+	// Fast-path: The min-heap satisfies the request with the first
+	// element.
+	top := p.mu.q[0]
+	p.mu.mark++
+	if p.mu.q.update(top, load, p.mu.mark) {
+		return newToken(p, load, top)
+	}
+
+	// Slow-path: Iterate over sorted entries.
+	// TODO(bob): Iterate directly over min-heap.
+	sorted := make([]*entryMeta, len(p.mu.q)-1)
+	copy(sorted, p.mu.q[1:])
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].costLowerThan(sorted[j])
+	})
+
+	for i := range sorted {
+		if p.mu.q.update(sorted[i], load, p.mu.mark) {
+			return newToken(p, load, sorted[i])
 		}
 	}
+
 	return nil
 }
 
@@ -133,14 +187,16 @@ func (p *Pool) pickLocked() Entry {
 // a call to Pick().
 func (p *Pool) Rebalance() {
 	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.mu.q.updateAll()
-	if p.mu.pickMightSucceed != nil {
-		p.mu.pickMightSucceed.Broadcast()
-	}
-	p.mu.Unlock()
+	p.pickMightSucceedLocked()
 }
 
 // Remove discards the given entry from the pool.
+//
+// Any currently-issued Tokens for the Entry will remain valid, but
+// became no-ops.
 func (p *Pool) Remove(e Entry) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -151,22 +207,38 @@ func (p *Pool) Remove(e Entry) {
 	}
 }
 
-// Wait is a blocking version of Pick().
-func (p *Pool) Wait(ctx context.Context) (Entry, error) {
-	ch := make(chan Entry, 1)
+// Wait is a blocking version of Pick() than can be interrupted by
+// Context cancellation.
+func (p *Pool) Wait(ctx context.Context, load int) (*Token, error) {
+	ch := make(chan *Token)
 
+	// This goroutine will loop until a call to pickLocked() succeeds.
 	go func() {
-		p.mu.Lock()
-		if p.mu.pickMightSucceed == nil {
-			p.mu.pickMightSucceed = sync.NewCond(&p.mu)
-		}
+		var picked *Token
 
-		var picked Entry
-		for picked = p.pickLocked(); picked == nil; picked = p.pickLocked() {
-			p.mu.pickMightSucceed.Wait()
+		// Loop using a Condition until we're able to select an entry,
+		// or the context has been canceled.
+		p.mu.Lock()
+		{
+			if p.mu.pickMightSucceed == nil {
+				p.mu.pickMightSucceed = sync.NewCond(&p.mu)
+			}
+
+			for picked = p.pickLocked(load); picked == nil && ctx.Err() == nil; picked = p.pickLocked(load) {
+				p.mu.pickMightSucceed.Wait()
+			}
 		}
 		p.mu.Unlock()
-		ch <- picked
+
+		if picked != nil {
+			select {
+			case <-ctx.Done():
+				// Release the token, since there's nobody to receive it.
+				picked.Release()
+			case ch <- picked:
+			}
+		}
+		close(ch)
 	}()
 
 	select {
@@ -174,5 +246,15 @@ func (p *Pool) Wait(ctx context.Context) (Entry, error) {
 		return nil, ctx.Err()
 	case picked := <-ch:
 		return picked, nil
+	}
+}
+
+// pickMightSucceedLocked is called to resume any Wait-ers.
+//
+// It uses Broadcast instead of Signal since there may be waiters
+// of different costs.
+func (p *Pool) pickMightSucceedLocked() {
+	if p.mu.pickMightSucceed != nil {
+		p.mu.pickMightSucceed.Broadcast()
 	}
 }

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -17,7 +17,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"math/rand"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,7 +33,7 @@ import (
 type trivial struct {
 	disabled bool
 	name     string
-	load     int
+	max      int
 	tier     int
 }
 
@@ -37,16 +41,18 @@ func (t *trivial) MarshalYAML() (interface{}, error) {
 	return t.name, nil
 }
 
+func (t *trivial) MaxLoad() int {
+	if t.disabled {
+		return 0
+	}
+	if t.max == 0 {
+		return 1
+	}
+	return t.max
+}
+
 func (t *trivial) String() string {
 	return t.name
-}
-
-func (t *trivial) Disabled() bool {
-	return t.disabled
-}
-
-func (t *trivial) Load() int {
-	return t.load
 }
 
 func (t *trivial) Tier() int {
@@ -66,12 +72,52 @@ func TestAddIdempotent(t *testing.T) {
 	a.Equal(1, p.Len())
 	p.Add(e)
 	a.Equal(1, p.Len())
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-	picked, err := p.Wait(ctx)
-	a.Same(e, picked)
-	a.NoError(err)
+func TestRefCount(t *testing.T) {
+	a := assert.New(t)
+
+	// Create a pool with one entry.
+	var p pool.Pool
+	e := &trivial{}
+
+	a.Equal(0, p.Load(e))
+	p.Add(e)
+	a.Equal(0, p.Load(e))
+
+	// It should be possible to Pick the entry out.
+	t0 := p.Pick()
+	a.NotNil(t0)
+	a.Same(e, t0.Entry())
+	a.Equal(1, p.Load(e))
+
+	// We can't pick it again until it's released.
+	a.Nil(p.Pick())
+
+	// Peeking is OK, however
+	a.Same(e, p.Peek().Entry())
+
+	a.True(t0.Release())
+	// Check over-release.
+	a.False(t0.Release())
+	a.Nil(t0.Entry())
+	a.Equal(0, p.Load(e))
+
+	t1 := p.Pick()
+	a.NotNil(t1)
+
+	a.Nil(t0.Entry())
+	a.Same(e, t1.Entry())
+	a.Equal(1, p.Load(e))
+
+	// Remove the entry and ensure that an issued Token still works
+	// and that it can still be released, which will be a no-op.
+	p.Remove(e)
+	a.Same(e, t1.Entry())
+	a.Equal(0, p.Load(e))
+	t1.Release()
+	a.Nil(p.Pick())
+	a.Equal(0, p.Load(e))
 }
 
 func TestEmptyPoolWait(t *testing.T) {
@@ -80,36 +126,72 @@ func TestEmptyPoolWait(t *testing.T) {
 	a.Nil(p.Pick())
 	a.Equal(0, p.Len())
 
-	ch := make(chan pool.Entry, 1)
+	ch := make(chan *pool.Token)
 	go func() {
-		picked, err := p.Wait(context.Background())
+		picked, err := p.Wait(context.Background(), 1)
 		a.NoError(err)
 		a.NotNil(picked)
 		ch <- picked
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-	picked, err := p.Wait(ctx)
-	a.Nil(picked)
-	a.True(errors.Is(err, context.DeadlineExceeded))
+	// Try with an already-canceled context.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	p.Add(&trivial{})
-	p.Rebalance()
+	picked, err := p.Wait(ctx, 1)
+	a.Nil(picked)
+	a.True(errors.Is(err, context.Canceled))
+
+	e := &trivial{}
+	p.Add(e)
+	log.Print("ADDED")
 
 	select {
 	case picked := <-ch:
-		a.NotNil(picked)
-	case <-time.NewTimer(time.Second).C:
+		a.Same(e, picked.Entry())
+	case <-time.NewTimer(10 * time.Minute).C:
 		a.Fail("timeout")
 	}
+}
+
+func TestLoadDistribution(t *testing.T) {
+	a := assert.New(t)
+	const count = 100
+	const minLoad = 2
+
+	loads := make([]int, count)
+	var p pool.Pool
+	for i := 0; i < count; i++ {
+		p.Add(&trivial{name: strconv.Itoa(i + minLoad), max: i + minLoad})
+		loads[i] = i + minLoad
+	}
+
+	rand.Shuffle(count, func(i, j int) {
+		loads[i], loads[j] = loads[j], loads[i]
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func(idx int) {
+			token, err := p.Wait(ctx, loads[idx])
+			if a.NoError(err) {
+				a.True(token.Release())
+			}
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestMarshalYAML(t *testing.T) {
 	a := assert.New(t)
 
-	e0 := &trivial{name: "e0", load: 2}
-	e1 := &trivial{name: "e1", load: 1}
+	e0 := &trivial{name: "e0"}
+	e1 := &trivial{name: "e1"}
 
 	var p pool.Pool
 	p.Add(e0)
@@ -136,7 +218,7 @@ func TestRemove(t *testing.T) {
 	a.Contains(p.All(), e0)
 	a.Contains(p.All(), e1)
 
-	a.Same(e0, p.Pick())
+	a.Same(e0, p.Pick().Entry())
 
 	p.Remove(e0)
 	a.Nil(p.Pick())
@@ -155,7 +237,10 @@ func TestSingletonPool(t *testing.T) {
 	p.Add(e)
 
 	for i := 0; i < 100; i++ {
-		a.Same(e, p.Pick())
+		t := p.Pick()
+		a.Same(e, t.Entry())
+		t.Release()
+		a.Nil(t.Entry())
 	}
 }
 
@@ -260,7 +345,11 @@ func TestThreeTier(t *testing.T) {
 	for i := range tier0 {
 		tier0[i].disabled = false
 	}
+
+	// Pick() will only ever take an entry out of rotation, so we need
+	// an explicit Rebalance() call here to kick all of the entries.
 	p.Rebalance()
+
 	checkRoundRobin(a, &p, tier0)
 	checkRoundRobin(a, &p, tier0)
 	checkRoundRobin(a, &p, tier0)
@@ -270,9 +359,11 @@ func checkRoundRobin(a *assert.Assertions, p *pool.Pool, expected []*trivial) {
 	seen := make(map[*trivial]bool, len(expected))
 
 	for range expected {
-		found := p.Pick().(*trivial)
+		t := p.Pick()
+		found := t.Entry().(*trivial)
 		a.Contains(expected, found)
 		a.Falsef(seen[found], "saw %s again", found)
 		seen[found] = true
+		t.Release()
 	}
 }

--- a/pkg/pool/token.go
+++ b/pkg/pool/token.go
@@ -1,0 +1,91 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pool
+
+import (
+	"runtime"
+	"sync"
+)
+
+// A Token represents the intent to use an Entry in the Pool. Tokens
+// should be released by callers in order to avoid delaying the return
+// of an entry to a pool.
+type Token struct {
+	mu struct {
+		sync.Mutex
+		entry *entryMeta
+		pool  *Pool
+	}
+	release int
+}
+
+func tokenFinalizer(t *Token) {
+	t.Release()
+}
+
+// newToken constructs a Token for the pool and entry.  It also sets up
+// a finalizer to automatically release the token should a caller fail
+// to do so. This finalizer will be cleared once the token is released
+// to avoid unnecessary work by the GC.
+func newToken(p *Pool, load int, entry *entryMeta) *Token {
+	t := &Token{release: -load}
+	t.mu.entry = entry
+	if load > 0 {
+		t.mu.pool = p
+		runtime.SetFinalizer(t, tokenFinalizer)
+	}
+	return t
+}
+
+// Entry retrieves the Entry that is tracked by the token.  This method
+// may be called as many times as desired until Release is called.  Once
+// the Token has been released, this method will return nil.
+func (t *Token) Entry() Entry {
+	t.mu.Lock()
+	ret := t.mu.entry
+	t.mu.Unlock()
+	if ret == nil {
+		return nil
+	}
+	return ret.Entry
+}
+
+// Release will return the associated Entry to the Pool.
+//
+// Release will return true the first time it is called and then false
+// thereafter.
+func (t *Token) Release() bool {
+	// See newToken().
+	runtime.SetFinalizer(t, nil)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e := t.mu.entry
+	t.mu.entry = nil
+
+	if t.mu.pool == nil {
+		return false
+	}
+
+	t.mu.pool.mu.Lock()
+	defer t.mu.pool.mu.Unlock()
+
+	// If the index is -1, then the Entry has been removed from the Pool.
+	if e.index != notInPQueue {
+		t.mu.pool.mu.q.update(e, t.release, e.mark)
+		t.mu.pool.pickMightSucceedLocked()
+	}
+	t.mu.pool = nil
+	return true
+}

--- a/pkg/testing/capture.go
+++ b/pkg/testing/capture.go
@@ -36,11 +36,8 @@ func Capture(ctx context.Context, dest io.Writer) (net.Addr, loop.Option, error)
 		_ = l.Close()
 	}()
 	tcp := l.(*net.TCPListener)
-	opt := loop.WithTCPHandler(tcp, func(ctx context.Context, conn *net.TCPConn) error {
+	opt := loop.WithHandler(tcp, func(ctx context.Context, conn net.Conn) error {
 		log.Printf("recording data from %s", conn.RemoteAddr())
-		if err := conn.CloseWrite(); err != nil {
-			return err
-		}
 		_, err := io.Copy(dest, conn)
 		return err
 	})

--- a/pkg/testing/chargen.go
+++ b/pkg/testing/chargen.go
@@ -35,7 +35,7 @@ func CharGen(ctx context.Context, bytesToSend int) (net.Addr, loop.Option, error
 		_ = l.Close()
 	}()
 	tcp := l.(*net.TCPListener)
-	opt := loop.WithTCPHandler(tcp, func(ctx context.Context, conn *net.TCPConn) error {
+	opt := loop.WithHandler(tcp, func(ctx context.Context, conn net.Conn) error {
 		for remaining := bytesToSend; remaining > 0; {
 			toSend := len(charBytes)
 			if remaining < toSend {

--- a/pkg/testing/ignore.go
+++ b/pkg/testing/ignore.go
@@ -31,7 +31,7 @@ func Ignore(ctx context.Context) (net.Addr, loop.Option, error) {
 		_ = l.Close()
 	}()
 	tcp := l.(*net.TCPListener)
-	opt := loop.WithTCPHandler(tcp, func(ctx context.Context, conn *net.TCPConn) error {
+	opt := loop.WithHandler(tcp, func(ctx context.Context, conn net.Conn) error {
 		<-ctx.Done()
 		return ctx.Err()
 	})


### PR DESCRIPTION
This change ensures that major configuration changes don't affect all
connections at once by smearing the maintenance cycle performed on each
connection.

The parameter is `BackendPool.MaintenanceTime` and defaults to thirty seconds.