### PR TITLE
Fix load not decreasing while overloaded.

### DIFF
--- a/pkg/balancer/balancer.go
+++ b/pkg/balancer/balancer.go
@@ -152,9 +152,9 @@ func (b *Balancer) Configure(ctx context.Context, cfg config.BackendPool, tolera
 }
 
 // IsOverloaded returns true if the given backend should be considered
-// to be in an overload situation.
+// to be in an overload situation (e.g. when draining).
 func (b *Balancer) IsOverloaded(backend *Backend) bool {
-	return b.p.Load(backend) >= backend.MaxLoad()
+	return b.p.IsOverloaded(backend)
 }
 
 // MarshalYAML implements yaml.Marshaler and provides a diagnostic

--- a/pkg/pool/p_queue.go
+++ b/pkg/pool/p_queue.go
@@ -88,7 +88,12 @@ func (q *entryPQueue) update(meta *entryMeta, loadDelta int, mark mark) bool {
 	meta.mark = mark
 	meta.maxLoad = meta.MaxLoad()
 	meta.tier = meta.Tier()
-	if meta.load+loadDelta <= meta.maxLoad {
+	// Only allow the load to increase by the delta, up to the max.
+	if loadDelta > 0 && meta.load+loadDelta <= meta.maxLoad {
+		meta.load += loadDelta
+		ret = true
+	} else if loadDelta <= 0 {
+		// But always allow load to be shed (e.g. drain a 0-cap backend)
 		meta.load += loadDelta
 		ret = true
 	}

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -77,6 +77,19 @@ func (p *Pool) All() []Entry {
 	return ret
 }
 
+// IsOverloaded returns true if the Entry is known to have a higher
+// load than its configured maximum (e.g. when draining).
+func (p *Pool) IsOverloaded(e Entry) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	meta := p.mu.canonical[e]
+	if meta == nil {
+		return true
+	}
+	return meta.load > meta.maxLoad
+}
+
 // Len returns the total size of the pool.
 func (p *Pool) Len() int {
 	p.mu.Lock()


### PR DESCRIPTION
This patch fixes an issue where the load on a Pool entry couldn't be decreased
when the Token was Released. Adds a test to ensure that draining behavior works
as expected. Balancer now delegates overload detection to Pool.